### PR TITLE
Always include vary header

### DIFF
--- a/src/actual.js
+++ b/src/actual.js
@@ -6,15 +6,18 @@ exports.handler = function (options) {
   return function (req, res, next) {
     var originHeader = req.headers['origin']
 
+    // Since we use the origin header to control what we return, that
+    // means we vary on origin
+    res.setHeader(constants['STR_VARY'], constants['STR_VARY_DETAILS'])
+
     // If either no origin was set, or the origin isn't supported, continue
-    // without setting any headers
+    // without setting any additional headers
     if (!originHeader || !matcher(originHeader)) {
       return next()
     }
 
     // if match was found, let's set some headers.
     res.setHeader(constants['AC_ALLOW_ORIGIN'], originHeader)
-    res.setHeader(constants['STR_VARY'], constants['STR_ORIGIN'])
     if (options.credentials) {
       res.setHeader(constants['AC_ALLOW_CREDS'], 'true')
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-module.exports = {
+const constants = {
   ALLOW_HEADERS: [
     'accept',
     'accept-version',
@@ -30,3 +30,11 @@ module.exports = {
   STR_ORIGIN: 'origin',
   HTTP_NO_CONTENT: 204
 }
+
+constants['STR_VARY_DETAILS'] = [
+  constants['STR_ORIGIN'],
+  constants['AC_REQ_METHOD'],
+  constants['AC_REQ_HEADERS']
+].join(',')
+
+module.exports = constants

--- a/test/cors.actual.spec.js
+++ b/test/cors.actual.spec.js
@@ -100,4 +100,15 @@ describe('CORS: simple / actual requests', function () {
       test.corsServer({})
     })
   })
+
+  it('Sets the vary header when origin not present', function (done) {
+    var server = test.corsServer({
+      origins: ['http://api.myapp.com', 'http://www.myapp.com']
+    })
+    request(server)
+        .get('/test')
+        .expect('vary', 'origin,access-control-request-method,access-control-request-headers')
+        .expect(200)
+        .end(done)
+  })
 })


### PR DESCRIPTION
See https://stackoverflow.com/a/45081016 for history, but in general
since the entire point of CORS is to respond differently based on
origin and CORS headers, we need to include those in the vary header.