### PR TITLE
Added definitions for restify-cors-middleware

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for restify-cors-middleware 1.0
+// Project: https://github.com/TabDigital/restify-cors-middleware
+// Definitions by: Daniel Thunell <https://github.com/dthunell>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+
+import { RequestHandler } from 'restify';
+
+declare namespace corsMiddleware {
+  interface Options {
+    /**
+     * an array of whitelisted origins
+     * can be both strings and regular expressions
+     */
+    origins: Array<string | RegExp>;
+    /** user defined headers to allow */
+    allowHeaders: string[];
+    /** user defined headers to expose */
+    exposeHeaders: string[];
+    /** if true, uses creds */
+    credentials?: boolean;
+    /** ms to cache preflight requests */
+    preflightMaxAge?: number;
+    /** customize preflight request handling */
+    preflightStrategy?: any;
+  }
+
+  interface CorsMiddleware {
+    actual: RequestHandler;
+    preflight: RequestHandler;
+  }
+}
+
+declare function corsMiddleware(options: corsMiddleware.Options): corsMiddleware.CorsMiddleware;
+export = corsMiddleware;


### PR DESCRIPTION
What are your thoughts on adding type definitions to this repository? Currently, @types/restify-cors-middleware is defined separately from restify-cors-middlware. Since you are picking up the torch with this package, I was wondering if you would mind doing the same with the type definitions by either adding the definitions to this package or by creating @types/restify-cors-middleware2 as well?

src/index.d.ts in this PR was taken from:
https://www.npmjs.com/package/@types/restify-cors-middleware
https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/restify-cors-middleware