### PR TITLE
remove_whitespace_from_header_values - Removing whitespace from header values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-cors-middleware2",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-cors-middleware2",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Datatrac Corporation",
   "license": "MIT",
   "description": "CORS middleware with full W3C spec support",

--- a/src/actual.js
+++ b/src/actual.js
@@ -22,7 +22,7 @@ exports.handler = function (options) {
       res.setHeader(constants.AC_ALLOW_CREDS, 'true')
     }
     res.setHeader(constants.AC_EXPOSE_HEADERS,
-      options.exposeHeaders.join(', '))
+      options.exposeHeaders.join(','))
 
     return next()
   }

--- a/src/preflight.js
+++ b/src/preflight.js
@@ -32,10 +32,10 @@ exports.handler = function (options) {
       }
 
       // 6.2.9
-      res.header(constants.AC_ALLOW_METHODS, allowedMethods.join(', '))
+      res.header(constants.AC_ALLOW_METHODS, allowedMethods.join(','))
 
       // 6.2.10
-      res.header(constants.AC_ALLOW_HEADERS, allowedHeaders.join(', '))
+      res.header(constants.AC_ALLOW_HEADERS, allowedHeaders.join(','))
     })
 
     res.send(constants.HTTP_NO_CONTENT)

--- a/test/cors.actual.spec.js
+++ b/test/cors.actual.spec.js
@@ -89,7 +89,7 @@ describe('CORS: simple / actual requests', function () {
       .get('/test')
       .set('Origin', 'http://api.myapp.com')
       .expect('access-control-allow-origin', 'http://api.myapp.com')
-      .expect('access-control-expose-headers', /HeaderA, HeaderB/) // custom
+      .expect('access-control-expose-headers', /HeaderA,HeaderB/) // custom
       .expect('access-control-expose-headers', /api-version/) // defaults
       .expect(200)
       .end(done)

--- a/test/cors.preflight.spec.js
+++ b/test/cors.preflight.spec.js
@@ -105,7 +105,7 @@ describe('CORS: preflight requests', function () {
       .options('/test')
       .set('Origin', 'http://api.myapp.com')
       .set('Access-Control-Request-Method', 'GET')
-      .expect('Access-Control-Allow-Methods', 'GET, OPTIONS')
+      .expect('Access-Control-Allow-Methods', 'GET,OPTIONS')
       .expect(204)
       .end(done)
   })


### PR DESCRIPTION
Header value might be encoded and whitespace technically could make the header broken.